### PR TITLE
Lägger till Genre-klass för att representera filmgenrer

### DIFF
--- a/src/main/java/com/example/ep_projekt/model/Genre.java
+++ b/src/main/java/com/example/ep_projekt/model/Genre.java
@@ -1,4 +1,35 @@
 package com.example.ep_projekt.model;
 
+// Importerar nödvändiga JPA-annoteringar för att använda ORM (Object-Relational Mapping)
+import jakarta.persistence.*;
+
+// Denna klass representerar en genre och den är embeddable, vilket innebär att den kan inkluderas som en del av en annan entitet.
+@Embeddable
 public class Genre {
+
+    // Fältet för att lagra genre-ID
+    private Long id;
+
+    // Fältet för att lagra genre-namn
+    private String name;
+
+    // Getter-metod för genre-ID
+    public Long getId() {
+        return id;
+    }
+
+    // Setter-metod för genre-ID
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    // Getter-metod för genre-namn
+    public String getName() {
+        return name;
+    }
+
+    // Setter-metod för genre-namn
+    public void setName(String name) {
+        this.name = name;
+    }
 }


### PR DESCRIPTION
Denna commit lägger till en ny Genre-klass som representerar filmgenrer, med fälten id och name. 
Klassen är markerad som @Embeddable och kan därför användas som en inbäddad entitet i andra objekt för att hantera filmens genreinformation på ett strukturerat sätt."